### PR TITLE
createSysID.js

### DIFF
--- a/Background Scripts/Create own SysID/createSysID.js
+++ b/Background Scripts/Create own SysID/createSysID.js
@@ -1,0 +1,9 @@
+var gr = new GlideRecord('sys_user');
+gr.initialize();
+gr.setValue('user_name', 'azeez.gaa');
+gr.setValue('first_name', 'Azeez');
+gr.setValue('last_name', 'Gaa');
+gr.setValue('sys_created_on', '1999-03-09 12:00:00');
+gr.setNewGuidValue('azeez.gaa');
+gr.autoSysFields();
+gr.insert();


### PR DESCRIPTION
Case

When creating new records, ServiceNow automatically generates a unique sys_id. Though at some rare places in the system you'll notice there isn't actually a 32-character sys_id used but just a string. What the?!

So could we do this ourselves? For example on a User record, with your own firstname.lastname or your nickname? Yes, you can!


How to

You only have to apply setNewGuidValue. Note this will only work for new records, not for updating records. I also applied autoSysFields. Just because I wanted to apply a custom Created date, so this would be my actual date of birth